### PR TITLE
Scrum 46 - Override styles of the message box buttons

### DIFF
--- a/FrontEnd/src/assets/main.css
+++ b/FrontEnd/src/assets/main.css
@@ -232,6 +232,46 @@ select {
   background-color: var(--el-fill-color-light) !important;
 }
 
+.el-message-box__content {
+  color: var(--color-dark) !important;
+}
+
+.el-message-box__btns .el-button:not(.el-button--primary) {
+  background-color: transparent !important;
+  border: 1px solid var(--color-primary) !important;
+  color: var(--color-primary) !important;
+  border-radius: 9999px !important;
+  font-size: 16px;
+  padding: 18px 20px !important;
+
+  transition:
+    background-color 0.3s ease,
+    transform 0.2s ease;
+}
+
+.el-message-box__btns .el-button:hover:not(.el-button--primary),
+.el-message-box__btns .el-button:focus:not(.el-button--primary) {
+  background-color: var(--color-primary-hover) !important;
+  border-color: var(--color-primary-primary) !important;
+  transform: translateY(-1px);
+}
+
+.el-message-box-icon--warning {
+  color: var(--color-warning) !important;
+}
+
+.el-message-box-icon--info {
+  color: var(--color-info) !important;
+}
+
+.el-message-box-icon--success {
+  color: var(--color-secondary) !important;
+}
+
+.el-message-box-icon--error {
+  color: var(--color-danger) !important;
+}
+
 .nav-links {
   display: flex;
   align-items: center;

--- a/FrontEnd/src/views/manager/ProjectManagement.vue
+++ b/FrontEnd/src/views/manager/ProjectManagement.vue
@@ -100,12 +100,12 @@ const getStatusText = (status) => {
 // Delete project
 const handleDelete = (row) => {
   ElMessageBox.confirm(
-    `Are you sure you want to delete the project "${row.name}"?`,
-    'Warning',
+    `Are you sure you want to delete the project "${row.name}"? This action cannot be undone.`,
+    'Confirm',
     {
+      confirmButtonClass: 'btn-danger',
       confirmButtonText: 'Confirm',
       cancelButtonText: 'Cancel',
-      type: 'warning',
     }
   )
     .then(async () => {

--- a/FrontEnd/src/views/manager/UserManagement.vue
+++ b/FrontEnd/src/views/manager/UserManagement.vue
@@ -79,12 +79,12 @@ const getUserRole = (role) => {
 // Delete user
 const handleDelete = (row) => {
   ElMessageBox.confirm(
-    `Are you sure you want to delete user ${row.name}?`,
-    'Warning',
+    `Are you sure you want to delete user ${row.name}? This action cannot be undone.`,
+    'Confirm',
     {
+      confirmButtonClass: 'btn-danger',
       confirmButtonText: 'Confirm',
       cancelButtonText: 'Cancel',
-      type: 'warning',
     }
   )
     .then(async () => {

--- a/FrontEnd/src/views/project/projectManage/Backlog.vue
+++ b/FrontEnd/src/views/project/projectManage/Backlog.vue
@@ -325,12 +325,12 @@ const handlePrev = async () => {
   if (activeStep.value > 0) {
     try {
       await ElMessageBox.confirm(
-        'Are you sure you want to go back?',
+        'Are you sure you want to go back a stage?',
         'Confirm',
         {
+          confirmButtonClass: 'btn-primary',
           confirmButtonText: 'Confirm',
           cancelButtonText: 'Cancel',
-          type: 'warning',
         }
       );
       const newStatus = activeStep.value - 1;
@@ -345,12 +345,12 @@ const handleNext = async () => {
   if (activeStep.value < steps.length - 1) {
     try {
       await ElMessageBox.confirm(
-        'Are you sure you want to go to the next step?',
+        'Are you sure you want to go to the next stage?',
         'Confirm',
         {
+          confirmButtonClass: 'btn-primary',
           confirmButtonText: 'Confirm',
           cancelButtonText: 'Cancel',
-          type: 'warning',
         }
       );
       const newStatus = activeStep.value + 1;
@@ -441,19 +441,19 @@ const handleDelete = async (row) => {
         'Permission Denied',
         {
           confirmButtonText: 'OK',
-          type: 'warning',
+          type: 'error',
         }
       );
       return;
     }
 
     await ElMessageBox.confirm(
-      'Are you sure you want to delete this task?',
+      'Are you sure you want to delete this task? This action cannot be undone.',
       'Confirm',
       {
+        confirmButtonClass: 'btn-danger',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
-        type: 'warning',
       }
     );
 
@@ -596,7 +596,7 @@ const handleEdit = (row, field) => {
       'Permission Denied',
       {
         confirmButtonText: 'OK',
-        type: 'warning',
+        type: 'error',
       }
     );
     return;

--- a/FrontEnd/src/views/project/projectManage/FolderDetails.vue
+++ b/FrontEnd/src/views/project/projectManage/FolderDetails.vue
@@ -355,6 +355,7 @@ const handleNewWhiteboard = async () => {
       'Enter whiteboard name',
       'New Whiteboard',
       {
+        confirmButtonClass: 'btn-primary',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
         inputPattern: /\S+/,
@@ -589,11 +590,11 @@ const showDeleteConfirm = async () => {
   try {
     await ElMessageBox.confirm(
       'Are you sure you want to delete this file? This action cannot be undone.',
-      'Delete Confirmation',
+      'Confirm',
       {
+        confirmButtonClass: 'btn-danger',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
-        type: 'warning',
       }
     );
     return true;

--- a/FrontEnd/src/views/project/projectManage/Map.vue
+++ b/FrontEnd/src/views/project/projectManage/Map.vue
@@ -64,7 +64,7 @@ function initMap() {
   });
   infoWindow = new google.maps.InfoWindow();
 
-/* Click on blank area to add new marker */
+  /* Click on blank area to add new marker */
   map.addListener('click', (e) => createMarker(e.latLng));
 
   /* Search box autocomplete */
@@ -133,6 +133,7 @@ async function fetchMarkersFromBackend() {
 /* --------- Create marker ---------- */
 function createMarker(latLng) {
   ElMessageBox.prompt('Enter marker title', 'New Marker', {
+    confirmButtonClass: 'btn-primary',
     confirmButtonText: 'Confirm',
     cancelButtonText: 'Cancel',
     inputValidator: (value) => {
@@ -144,6 +145,7 @@ function createMarker(latLng) {
   })
     .then(({ value: title }) => {
       ElMessageBox.prompt('Enter marker description', 'Description', {
+        confirmButtonClass: 'btn-primary',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
         inputType: 'textarea',
@@ -247,6 +249,7 @@ function openInfoWindow(data) {
 /* --------- Edit marker ---------- */
 function editMarker(data) {
   ElMessageBox.prompt('Enter marker title', 'Edit Marker', {
+    confirmButtonClass: 'btn-primary',
     confirmButtonText: 'Confirm',
     cancelButtonText: 'Cancel',
     inputValue: data.title,
@@ -259,6 +262,7 @@ function editMarker(data) {
   })
     .then(({ value: newTitle }) => {
       ElMessageBox.prompt('Enter marker description', 'Edit Description', {
+        confirmButtonClass: 'btn-primary',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
         inputValue: data.desc,
@@ -298,12 +302,12 @@ function editMarker(data) {
 /* --------- Delete marker ---------- */
 function deleteMarker(data) {
   ElMessageBox.confirm(
-    'Are you sure you want to delete this marker?',
-    'Delete Confirmation',
+    'Are you sure you want to delete this marker? This action cannot be undone.',
+    'Confirm',
     {
+      confirmButtonClass: 'btn-danger',
       confirmButtonText: 'Confirm',
       cancelButtonText: 'Cancel',
-      type: 'warning',
     }
   )
     .then(async () => {

--- a/FrontEnd/src/views/project/projectManage/ProjectDetails.vue
+++ b/FrontEnd/src/views/project/projectManage/ProjectDetails.vue
@@ -162,11 +162,11 @@ const handleLeaveProject = async () => {
   try {
     await ElMessageBox.confirm(
       'Are you sure you want to leave this project?',
-      'Warning',
+      'Confirm',
       {
+        confirmButtonClass: 'btn-danger',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
-        type: 'warning',
       }
     );
 
@@ -204,12 +204,12 @@ const handleLeaveProject = async () => {
 const handleDismissProject = async () => {
   try {
     await ElMessageBox.confirm(
-      'Are you sure you want to dismiss this project? This action cannot be undone!',
-      'Warning',
+      'Are you sure you want to delete this project? This action cannot be undone.',
+      'Confirm',
       {
+        confirmButtonClass: 'btn-danger',
         confirmButtonText: 'Confirm',
         cancelButtonText: 'Cancel',
-        type: 'error',
       }
     );
 


### PR DESCRIPTION
In this PR:
- Override the base message box button styles to match other buttons in the app
- Add custom btn classes where needed
- Remove icons from message boxes, keeping only when access was denied
- improved copy for delete dialogs (change title to confirm, add "this action cannot be undone")