### PR TITLE
Scrum 110 - Add JWT token check on page refresh and cache check

### DIFF
--- a/BackEnd/src/main/java/org/sds/elevateconnect/service/UserService.java
+++ b/BackEnd/src/main/java/org/sds/elevateconnect/service/UserService.java
@@ -27,6 +27,12 @@ public class UserService implements IUserService {
     @Autowired
     private InviteCodeService inviteCodeService;
 
+    private final JWTUtils jwtUtils;
+
+    public UserService(JWTUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
     @Override
     public Result login(String email, String password, HttpSession session) {
         User user = userMapper.getUserByEmail(email);
@@ -39,7 +45,7 @@ public class UserService implements IUserService {
             claims.put("id", user.getId());
             claims.put("username", user.getFirstName());
 
-            String jwt = JWTUtils.generateJwt(claims);
+            String jwt = jwtUtils.generateJwt(claims);
 
             session.setAttribute("user", user.getFirstName());
 

--- a/BackEnd/src/main/java/org/sds/elevateconnect/utils/JWTUtils.java
+++ b/BackEnd/src/main/java/org/sds/elevateconnect/utils/JWTUtils.java
@@ -7,11 +7,18 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import java.util.Date;
 import java.util.Map;
 
-public class JWTUtils {
-    private static final String signKey = "41113";
-    private static final Long expire = 86400000L;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
-    public static String generateJwt(Map<String, Object> claims){
+@Component
+public class JWTUtils {
+
+    @Value("${jwt.sign-key}")
+    private String signKey;
+    
+    private static final Long expire = 1000L * 60 * 60 * 24 * 30; // 30 days
+
+    public String generateJwt(Map<String, Object> claims){
         return Jwts.builder()
                 .addClaims(claims)
                 .signWith(SignatureAlgorithm.HS256, signKey)
@@ -19,7 +26,7 @@ public class JWTUtils {
                 .compact();
     }
 
-    public static Claims parseJWT(String jwt){
+    public Claims parseJWT(String jwt){
         return Jwts.parser()
                 .setSigningKey(signKey)
                 .parseClaimsJws(jwt)

--- a/BackEnd/src/main/java/org/sds/elevateconnect/utils/LoginCheckInterceptor.java
+++ b/BackEnd/src/main/java/org/sds/elevateconnect/utils/LoginCheckInterceptor.java
@@ -10,6 +10,13 @@ import org.springframework.web.servlet.HandlerInterceptor;
 @Component
 @Slf4j
 public class LoginCheckInterceptor implements HandlerInterceptor {
+
+    private final JWTUtils jwtUtils;
+
+    public LoginCheckInterceptor(JWTUtils jwtUtils) {
+        this.jwtUtils = jwtUtils;
+    }
+
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         String token = request.getHeader("authorization");
@@ -18,7 +25,7 @@ public class LoginCheckInterceptor implements HandlerInterceptor {
             return false;
         }
         try {
-            Claims claims = JWTUtils.parseJWT(token);
+            Claims claims = jwtUtils.parseJWT(token);
         } catch (Exception e) {
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;

--- a/BackEnd/src/main/resources/application.yml
+++ b/BackEnd/src/main/resources/application.yml
@@ -39,3 +39,6 @@ aliyun:
 miro:
   client-id: ${VITE_MIRO_CLIENT_ID}
   client-secret: ${VITE_MIRO_CLIENT_SECRET}
+
+jwt:
+  sign-key: ${JWT_SIGN_KEY}

--- a/FrontEnd/package-lock.json
+++ b/FrontEnd/package-lock.json
@@ -13,6 +13,7 @@
         "@mirohq/miro-api": "^2.2.4",
         "axios": "^1.8.4",
         "element-plus": "^2.9.7",
+        "jwt-decode": "^4.0.0",
         "pinia": "^3.0.3",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
@@ -2563,6 +2564,14 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/kolorist": {

--- a/FrontEnd/package.json
+++ b/FrontEnd/package.json
@@ -15,6 +15,7 @@
     "@mirohq/miro-api": "^2.2.4",
     "axios": "^1.8.4",
     "element-plus": "^2.9.7",
+    "jwt-decode": "^4.0.0",
     "pinia": "^3.0.3",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"


### PR DESCRIPTION
In this PR
- Add .env variable for JWT secret, should not be stored in code. NOTE you will need to set this in your local .env, just do JWT_SIGN_KEY as a new vairable and use [](https://jwtsecrets.com/) to generate a new key. Use secret length of 256
- This will not boot the user out automatically if their key expires, the next time they refresh the page, it will kick them out
- Add check on frontend for expired key, with error handling.